### PR TITLE
Fix the notification query param LIMIT doc

### DIFF
--- a/content/en/methods/notifications.md
+++ b/content/en/methods/notifications.md
@@ -67,7 +67,7 @@ min_id
 : String. Return results immediately newer than this ID
 
 limit
-: Integer. Maximum number of results to return. Defaults to 15 notifications. Max 30 notifications.
+: Integer. Maximum number of results to return. Defaults to 40 notifications. Max notifications depends on the limit param.
 
 types[]
 : Array of String. Types to include in the result.


### PR DESCRIPTION
The notification query param LIMIT should return 40 notifications as default & Maximum depends on the LIMIT param value as per the code in api/v1/notifications_controller